### PR TITLE
Add version command

### DIFF
--- a/sensu/goplugin.go
+++ b/sensu/goplugin.go
@@ -122,7 +122,7 @@ func (p *basePlugin) initPlugin() error {
 		Use:   "version",
 		Short: "Print the version number of this plugin",
 		Run: func(cmd *cobra.Command, args []string) {
-			version.Version()
+			fmt.Println(version.Version())
 		},
 	})
 

--- a/sensu/goplugin.go
+++ b/sensu/goplugin.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 
 	"github.com/sensu/sensu-go/types"
+	"github.com/sensu/sensu-plugins-go-library/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -116,6 +117,15 @@ func (p *basePlugin) initPlugin() error {
 	p.errorLogFunction = func(format string, a ...interface{}) {
 		_, _ = fmt.Fprintf(os.Stderr, format, a)
 	}
+
+	p.cmd.AddCommand(&cobra.Command{
+		Use:   "version",
+		Short: "Print the version number of this plugin",
+		Run: func(cmd *cobra.Command, args []string) {
+			version.Version()
+		},
+	})
+
 	return p.setupFlags(p.cmd)
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -8,6 +8,6 @@ var (
 	date    = "unknown"
 )
 
-func Version() {
+func Version() string {
 	fmt.Printf("%v, commit %v, built at %v\n", version, commit, date)
 }

--- a/version/version.go
+++ b/version/version.go
@@ -9,5 +9,5 @@ var (
 )
 
 func Version() string {
-	fmt.Printf("%v, commit %v, built at %v\n", version, commit, date)
+	return fmt.Printf("%v, commit %v, built at %v", version, commit, date)
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import "fmt"
+
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
+func Version() {
+	fmt.Printf("%v, commit %v, built at %v\n", version, commit, date)
+}


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

Allows version information to be set via LDFLAGS. For example, the following can be added to a project's `.goreleaser.yml`:

```
ldflags: '-s -w -X github.com/sensu-community/sensu-plugin-sdk/version.build={{.Version}} -X github.com/sensu-community/sensu-plugin-sdk/version.commit={{.Commit}} -X github.com/sensu-community/sensu-plugin-sdk/version.date={{.Date}}'
```