### PR TITLE
Log an error if plugin fails to initialize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ## Unreleased
 
 ### Fixed
-- Logs a fatal error if the plugin fails to initialize.
+- Logs an error if the plugin fails to initialize.
 
 ## [0.5.0] - 2020-02-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- Logs a fatal error if the plugin fails to initialize.
+
 ## [0.5.0] - 2020-02-05
 
 ### Added

--- a/sensu/gocheck.go
+++ b/sensu/gocheck.go
@@ -40,7 +40,7 @@ func NewGoCheck(config *PluginConfig, options []*PluginConfigOption,
 
 	check.pluginWorkflowFunction = check.goCheckWorkflow
 	if err := check.initPlugin(); err != nil {
-		log.Fatalf("failed to initialize check plugin: %s", err)
+		log.Printf("failed to initialize check plugin: %s", err)
 	}
 
 	return check

--- a/sensu/gocheck.go
+++ b/sensu/gocheck.go
@@ -2,6 +2,7 @@ package sensu
 
 import (
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/sensu/sensu-go/types"
@@ -38,7 +39,9 @@ func NewGoCheck(config *PluginConfig, options []*PluginConfigOption,
 	}
 
 	check.pluginWorkflowFunction = check.goCheckWorkflow
-	check.initPlugin()
+	if err := check.initPlugin(); err != nil {
+		log.Fatalf("failed to initialize check plugin: %s", err)
+	}
 
 	return check
 }

--- a/sensu/gohandler.go
+++ b/sensu/gohandler.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/sensu/sensu-go/types"
 	"log"
+
+	"github.com/sensu/sensu-go/types"
 )
 
 type GoHandler struct {
@@ -33,7 +34,7 @@ func NewGoHandler(config *PluginConfig, options []*PluginConfigOption,
 
 	goHandler.pluginWorkflowFunction = goHandler.goHandlerWorkflow
 	if err := goHandler.initPlugin(); err != nil {
-		log.Fatalf("failed to initialize handler plugin: %s", err)
+		log.Printf("failed to initialize handler plugin: %s", err)
 	}
 
 	return goHandler

--- a/sensu/gohandler.go
+++ b/sensu/gohandler.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/sensu/sensu-go/types"
+	"log"
 )
 
 type GoHandler struct {
@@ -31,7 +32,9 @@ func NewGoHandler(config *PluginConfig, options []*PluginConfigOption,
 	}
 
 	goHandler.pluginWorkflowFunction = goHandler.goHandlerWorkflow
-	goHandler.initPlugin()
+	if err := goHandler.initPlugin(); err != nil {
+		log.Fatalf("failed to initialize handler plugin: %s", err)
+	}
 
 	return goHandler
 }

--- a/sensu/gomutator.go
+++ b/sensu/gomutator.go
@@ -38,7 +38,7 @@ func NewGoMutator(config *PluginConfig, options []*PluginConfigOption,
 	}
 	goMutator.pluginWorkflowFunction = goMutator.goMutatorWorkflow
 	if err := goMutator.initPlugin(); err != nil {
-		log.Fatalf("failed to initialize mutator plugin: %s", err)
+		log.Printf("failed to initialize mutator plugin: %s", err)
 	}
 	return goMutator
 }

--- a/sensu/gomutator.go
+++ b/sensu/gomutator.go
@@ -3,9 +3,11 @@ package sensu
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/sensu/sensu-go/types"
 	"io"
+	"log"
 	"os"
+
+	"github.com/sensu/sensu-go/types"
 )
 
 type GoMutator struct {
@@ -35,7 +37,9 @@ func NewGoMutator(config *PluginConfig, options []*PluginConfigOption,
 		executeFunction:    executeFunction,
 	}
 	goMutator.pluginWorkflowFunction = goMutator.goMutatorWorkflow
-	goMutator.initPlugin()
+	if err := goMutator.initPlugin(); err != nil {
+		log.Fatalf("failed to initialize mutator plugin: %s", err)
+	}
 	return goMutator
 }
 


### PR DESCRIPTION
Signed-off-by: Nikki Attea <nikki@sensu.io>

Log surfaces errors during plugin initialization:
```
$ cat event.json | go run main.go --tags baby="yoda"
2020/02/05 15:00:01 failed to initialize handler plugin: Value type does not match Default type: map != string
Error: unknown flag: --tags
Usage:
  sensu-wavefront-handler [flags]
  sensu-wavefront-handler [command]
...
```