### PR TITLE
Silence errors and fix error formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - Logs an error if the plugin fails to initialize.
+- Prevent duplicated error messages fix the formatting.
 
 ## [0.5.0] - 2020-02-05
 

--- a/sensu/goplugin.go
+++ b/sensu/goplugin.go
@@ -120,8 +120,9 @@ func (p *basePlugin) initPlugin() error {
 	}
 
 	p.cmd.AddCommand(&cobra.Command{
-		Use:   "version",
-		Short: "Print the version number of this plugin",
+		Use:           "version",
+		Short:         "Print the version number of this plugin",
+		SilenceErrors: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Println(version.Version())
 		},
@@ -217,9 +218,6 @@ func (p *basePlugin) cobraExecuteFunction(args []string) error {
 	}
 
 	exitStatus, err := p.pluginWorkflowFunction(args)
-	if err != nil {
-		fmt.Fprintf(p.cmd.OutOrStdout(), "Error executing plugin: %s", err)
-	}
 	p.exitStatus = exitStatus
 
 	return err

--- a/sensu/goplugin.go
+++ b/sensu/goplugin.go
@@ -104,8 +104,9 @@ func (goPlugin *basePlugin) readSensuEvent() error {
 
 func (p *basePlugin) initPlugin() error {
 	p.cmd = &cobra.Command{
-		Use:   p.config.Name,
-		Short: p.config.Short,
+		Use:           p.config.Name,
+		Short:         p.config.Short,
+		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := viper.BindPFlags(cmd.Flags()); err != nil {
 				return err
@@ -115,7 +116,7 @@ func (p *basePlugin) initPlugin() error {
 	}
 	p.exitFunction = os.Exit
 	p.errorLogFunction = func(format string, a ...interface{}) {
-		_, _ = fmt.Fprintf(os.Stderr, format, a)
+		_, _ = fmt.Fprintf(os.Stderr, format, a...)
 	}
 
 	p.cmd.AddCommand(&cobra.Command{


### PR DESCRIPTION
Without this commit, errors are logged twice and there's a bug in formatting:

```bash
Error executing plugin: error validating input: the path to the SSL certificate keystore is requiredError: error validating input: the path to the SSL certificate keystore is required
Usage:
  sensu-puppet-handler [flags]
  sensu-puppet-handler [command]

[...]

Error executing [sensu-puppet-handler error validating input: the path to the SSL certificate keystore is required]: %!v(MISSING)
exit status 1
```

With this PR:
```bash
Usage:
  sensu-puppet-handler [flags]
  sensu-puppet-handler [command]

[...]

Error executing sensu-puppet-handler: error validating input: the path to the SSL certificate keystore is required
exit status 1
```