### PR TITLE
Add helpers for TLS options

### DIFF
--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -113,6 +113,10 @@ type CoreClientConfig struct {
 	// CACert, if non-nil, will be used to configure TLS communication. This
 	// is only needed when using a self-signed certificate.
 	CACert *x509.Certificate
+
+	// InsecureSkipVerify disables TLS hostname verification. This should not
+	// be used outside of testing!
+	InsecureSkipVerify bool
 }
 
 func newRequest(ctx context.Context, resource corev2.Resource, verb, server, apikey string) (*http.Request, error) {
@@ -276,6 +280,10 @@ func NewCoreClient(config CoreClientConfig) *CoreClient {
 		client.HTTPClient.Transport.(*http.Transport).TLSClientConfig = &tls.Config{
 			RootCAs: rootCAs,
 		}
+	}
+	// Disable TLS hostname verification
+	if config.InsecureSkipVerify {
+		client.HTTPClient.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify = true
 	}
 	return client
 }

--- a/httpclient/client_test.go
+++ b/httpclient/client_test.go
@@ -12,6 +12,7 @@ func TestClientGet(t *testing.T) {
 	config := httpclient.CoreClientConfig{
 		URL:    server.URL,
 		APIKey: "use transport layer security",
+		CACert: server.Certificate(),
 	}
 	cl := httpclient.NewCoreClient(config)
 	req := httpclient.NewEventRequest("default", "server", "network")
@@ -29,6 +30,7 @@ func TestClientPut(t *testing.T) {
 	config := httpclient.CoreClientConfig{
 		URL:    server.URL,
 		APIKey: "use transport layer security",
+		CACert: server.Certificate(),
 	}
 	cl := httpclient.NewCoreClient(config)
 	check := corev2.FixtureCheckConfig("fake")
@@ -43,6 +45,7 @@ func TestClientPost(t *testing.T) {
 	config := httpclient.CoreClientConfig{
 		URL:    server.URL,
 		APIKey: "use transport layer security",
+		CACert: server.Certificate(),
 	}
 	cl := httpclient.NewCoreClient(config)
 	check := corev2.FixtureCheckConfig("fake")
@@ -57,6 +60,7 @@ func TestClientDelete(t *testing.T) {
 	config := httpclient.CoreClientConfig{
 		URL:    server.URL,
 		APIKey: "use transport layer security",
+		CACert: server.Certificate(),
 	}
 	cl := httpclient.NewCoreClient(config)
 	check := corev2.FixtureCheckConfig("fake")

--- a/httpclient/example_test.go
+++ b/httpclient/example_test.go
@@ -12,7 +12,7 @@ import (
 	corev2 "github.com/sensu/sensu-go/api/core/v2"
 )
 
-var server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+var server = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 	if req.Method == http.MethodGet {
 		event := corev2.FixtureEvent("server", "network")
 		_ = json.NewEncoder(w).Encode(event)
@@ -23,6 +23,7 @@ func ExampleCoreClient_GetResource() {
 	config := httpclient.CoreClientConfig{
 		URL:    server.URL,
 		APIKey: "use transport layer security",
+		CACert: server.Certificate(),
 	}
 	cl := httpclient.NewCoreClient(config)
 	req := httpclient.NewEventRequest("default", "server", "network")
@@ -39,6 +40,7 @@ func ExampleCoreClient_PutResource() {
 	config := httpclient.CoreClientConfig{
 		URL:    server.URL,
 		APIKey: "use transport layer security",
+		CACert: server.Certificate(),
 	}
 	cl := httpclient.NewCoreClient(config)
 	check := corev2.FixtureCheckConfig("fake")
@@ -54,6 +56,7 @@ func ExampleCoreClient_PostResource() {
 	config := httpclient.CoreClientConfig{
 		URL:    server.URL,
 		APIKey: "use transport layer security",
+		CACert: server.Certificate(),
 	}
 	cl := httpclient.NewCoreClient(config)
 	check := corev2.FixtureCheckConfig("fake")
@@ -69,6 +72,7 @@ func ExampleCoreClient_DeleteResource() {
 	config := httpclient.CoreClientConfig{
 		URL:    server.URL,
 		APIKey: "use transport layer security",
+		CACert: server.Certificate(),
 	}
 	cl := httpclient.NewCoreClient(config)
 	check := corev2.FixtureCheckConfig("fake")

--- a/sensu/security.go
+++ b/sensu/security.go
@@ -1,0 +1,52 @@
+package sensu
+
+import (
+	"crypto/x509"
+	"io/ioutil"
+)
+
+// SecurityConfig holds configuration for securely communicating with a Sensu
+// backend.
+type SecurityConfig struct {
+	// CACertificate provide a means to use a self-signed certificate with
+	// an HTTP client.
+	CACertificate string
+
+	// InsecureSkipVerify skips hostname verification for certificates. It is
+	// not recommended to use this outside of testing.
+	InsecureSkipVerify bool
+}
+
+// SensuSecurityOptions adds the following flags to a plugin:
+//   --sensu-ca-cert
+//   --sensu-insecure-skip-verify
+func SensuSecurityOptions(config *SecurityConfig) []*PluginConfigOption {
+	return []*PluginConfigOption{
+		{
+			Value:    &config.CACertificate,
+			Path:     "sensu-ca-cert",
+			Env:      "SENSU_CA_CERT",
+			Argument: "sensu-ca-cert",
+			Usage:    "--sensu-ca-cert /etc/ssl/self-signed-ca.crt",
+		},
+		{
+			Value:    &config.InsecureSkipVerify,
+			Path:     "sensu-insecure-skip-verify",
+			Env:      "SENSU_INSECURE_SKIP_VERIFY",
+			Argument: "sensu-insecure-skip-verify",
+			Usage:    "--sensu-insecure-skip-verify (disables TLS hostname verification)",
+		},
+	}
+}
+
+// GetCACertificate gets the CA certificate associated with the path stored at
+// CACertificate. It returns an error if the file is not found, or if the
+// certificate is not a valid x509 certificate. The certificate can be provided
+// to the CoreClient in the httpclient package.
+func (s *SecurityConfig) GetCACertificate() (*x509.Certificate, error) {
+	b, err := ioutil.ReadFile(s.CACertificate)
+	if err != nil {
+		return nil, err
+	}
+	return x509.ParseCertificate(b)
+}

--- a/sensu/security_test.go
+++ b/sensu/security_test.go
@@ -1,0 +1,53 @@
+package sensu_test
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/sensu-community/sensu-plugin-sdk/sensu"
+)
+
+func TestSecurityConfig(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer server.Close()
+	tf, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		os.Remove(tf.Name())
+	}()
+	if _, err := tf.Write(server.Certificate().Raw); err != nil {
+		t.Fatal(err)
+	}
+	if err := tf.Close(); err != nil {
+		t.Fatal(err)
+	}
+	cfg := sensu.SecurityConfig{
+		CACertificate: tf.Name(),
+	}
+	cert, err := cfg.GetCACertificate()
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := &http.Client{}
+	rootCAs := x509.NewCertPool()
+	rootCAs.AddCert(cert)
+	client.Transport = &http.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs: rootCAs,
+		},
+	}
+	req, err := http.NewRequest("GET", server.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Do(req); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Closes #27, and also fixes a bug that could result in a panic when CA certs are configured.

Signed-off-by: Eric Chlebek <eric@sensu.io>