### PR TITLE
Allow single string override for slice of string values

### DIFF
--- a/sensu/goplugin.go
+++ b/sensu/goplugin.go
@@ -247,6 +247,15 @@ func validateEvent(event *types.Event) error {
 
 func setOptionValue(opt *PluginConfigOption, valueStr string) error {
 	optVal := reflect.Indirect(reflect.ValueOf(opt.Value))
+	if optVal.Type().Kind() == reflect.Slice {
+		_, ok := opt.Value.(*[]string)
+		if ok {
+			a := []string{}
+			a = append(a, valueStr)
+			optVal.Set(reflect.ValueOf(a))
+			return nil
+		}
+	}
 	if optVal.Type().Kind() == reflect.String {
 		optVal.Set(reflect.ValueOf(valueStr))
 		return nil

--- a/sensu/goplugin.go
+++ b/sensu/goplugin.go
@@ -247,12 +247,9 @@ func validateEvent(event *types.Event) error {
 
 func setOptionValue(opt *PluginConfigOption, valueStr string) error {
 	optVal := reflect.Indirect(reflect.ValueOf(opt.Value))
-	if optVal.Type().Kind() == reflect.Slice {
-		_, ok := opt.Value.(*[]string)
-		if ok {
-			a := []string{}
-			a = append(a, valueStr)
-			optVal.Set(reflect.ValueOf(a))
+	if typ := optVal.Type(); typ.Kind() == reflect.Slice {
+		if typ.Elem().Kind() == reflect.String {
+			optVal.Set(reflect.Append(optVal, reflect.ValueOf(valueStr)))
 			return nil
 		}
 	}

--- a/sensu/goplugin_test.go
+++ b/sensu/goplugin_test.go
@@ -26,6 +26,24 @@ func TestSetOptionValue_EmptyString(t *testing.T) {
 	assert.Equal(t, "", finalValue)
 }
 
+func TestSetOptionValue_Slice(t *testing.T) {
+	var finalValue []string
+	option := defaultOption1
+	option.Value = &finalValue
+	err := setOptionValue(&option, "abc")
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"abc"}, finalValue)
+}
+
+func TestSetOptionValue_EmptySlice(t *testing.T) {
+	var finalValue []string
+	option := defaultOption1
+	option.Value = &finalValue
+	err := setOptionValue(&option, "")
+	assert.Nil(t, err)
+	assert.Equal(t, []string{""}, finalValue)
+}
+
 func TestSetOptionValue_ValidUint64(t *testing.T) {
 	var finalValue uint64
 	option := defaultOption1

--- a/sensu/goplugin_test.go
+++ b/sensu/goplugin_test.go
@@ -51,7 +51,7 @@ func TestSetOptionValue_SliceType(t *testing.T) {
 	option.Value = &finalValue
 	err := setOptionValue(&option, "abc")
 	assert.Nil(t, err)
-	assert.Equal(t, []string{"abc"}, finalValue)
+	assert.Equal(t, stringSlice{"abc"}, finalValue)
 }
 
 func TestSetOptionValue_ValidUint64(t *testing.T) {

--- a/sensu/goplugin_test.go
+++ b/sensu/goplugin_test.go
@@ -44,6 +44,16 @@ func TestSetOptionValue_EmptySlice(t *testing.T) {
 	assert.Equal(t, []string{""}, finalValue)
 }
 
+func TestSetOptionValue_SliceType(t *testing.T) {
+	type stringSlice []string
+	var finalValue stringSlice
+	option := defaultOption1
+	option.Value = &finalValue
+	err := setOptionValue(&option, "abc")
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"abc"}, finalValue)
+}
+
 func TestSetOptionValue_ValidUint64(t *testing.T) {
 	var finalValue uint64
 	option := defaultOption1


### PR DESCRIPTION
Issue surfaced in https://github.com/sensu/sensu-email-handler/issues/49 when trying to use an annotation to override an argument that is a slice of strings.

This change takes the value from the annotation and creates a single element slice to return.

Signed-off-by: Todd Campbell <todd@sensu.io>