### PR TITLE
Fix a regression that broke JSON arrays for []string

### DIFF
--- a/sensu/goplugin.go
+++ b/sensu/goplugin.go
@@ -248,6 +248,9 @@ func validateEvent(event *types.Event) error {
 func setOptionValue(opt *PluginConfigOption, valueStr string) error {
 	optVal := reflect.Indirect(reflect.ValueOf(opt.Value))
 	if typ := optVal.Type(); typ.Kind() == reflect.Slice {
+		if err := json.Unmarshal([]byte(valueStr), &opt.Value); err == nil {
+			return nil
+		}
 		if typ.Elem().Kind() == reflect.String {
 			optVal.Set(reflect.Append(optVal, reflect.ValueOf(valueStr)))
 			return nil

--- a/sensu/goplugin_test.go
+++ b/sensu/goplugin_test.go
@@ -54,6 +54,15 @@ func TestSetOptionValue_SliceType(t *testing.T) {
 	assert.Equal(t, stringSlice{"abc"}, finalValue)
 }
 
+func TestSetOptionValue_JSONArray(t *testing.T) {
+	var finalValue []string
+	option := defaultOption1
+	option.Value = &finalValue
+	err := setOptionValue(&option, `["abc","def"]`)
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"abc", "def"}, finalValue)
+}
+
 func TestSetOptionValue_ValidUint64(t *testing.T) {
 	var finalValue uint64
 	option := defaultOption1


### PR DESCRIPTION
The previous commit made it impossible to use a JSON array of strings. This commit tries JSON parsing first, and if it fails, puts the contents of the annotation in the slice.