### PR TITLE
ensure that for string slice annotations, the current value is overwr…

### DIFF
--- a/sensu/goplugin.go
+++ b/sensu/goplugin.go
@@ -252,7 +252,8 @@ func setOptionValue(opt *PluginConfigOption, valueStr string) error {
 			return nil
 		}
 		if typ.Elem().Kind() == reflect.String {
-			optVal.Set(reflect.Append(optVal, reflect.ValueOf(valueStr)))
+			empty := []string{}
+			optVal.Set(reflect.Append(reflect.ValueOf(empty), reflect.ValueOf(valueStr)))
 			return nil
 		}
 	}

--- a/sensu/goplugin_test.go
+++ b/sensu/goplugin_test.go
@@ -27,7 +27,7 @@ func TestSetOptionValue_EmptyString(t *testing.T) {
 }
 
 func TestSetOptionValue_Slice(t *testing.T) {
-	var finalValue []string
+	finalValue := []string{"def"}
 	option := defaultOption1
 	option.Value = &finalValue
 	err := setOptionValue(&option, "abc")
@@ -36,7 +36,7 @@ func TestSetOptionValue_Slice(t *testing.T) {
 }
 
 func TestSetOptionValue_EmptySlice(t *testing.T) {
-	var finalValue []string
+	finalValue := []string{"def"}
 	option := defaultOption1
 	option.Value = &finalValue
 	err := setOptionValue(&option, "")
@@ -46,7 +46,7 @@ func TestSetOptionValue_EmptySlice(t *testing.T) {
 
 func TestSetOptionValue_SliceType(t *testing.T) {
 	type stringSlice []string
-	var finalValue stringSlice
+	finalValue := stringSlice{"def"}
 	option := defaultOption1
 	option.Value = &finalValue
 	err := setOptionValue(&option, "abc")


### PR DESCRIPTION
Ensure that for string slice annotations, the current value is overwritten, not appended to.

Updated tests to make sure that prior value is overwritten.

Signed-off-by: Todd Campbell <todd@sensu.io>