### PR TITLE
working secret option that hides default value from option usage message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Added support for to designated PluginConfigOptions as Secret. If Secret, the default value for the argument will not be displayed in the usage message. This prevents sensitive values stored in envvars from leaking into the usage message.
 
 ## [0.7.0] - 2020-06-03
 

--- a/sensu/gohandler_test.go
+++ b/sensu/gohandler_test.go
@@ -36,6 +36,7 @@ var (
 		Path:      "path1",
 		Shorthand: "d",
 		Usage:     "First argument",
+		Secret:    true,
 	}
 
 	defaultOption2 = PluginConfigOption{

--- a/sensu/gomutator_test.go
+++ b/sensu/gomutator_test.go
@@ -33,6 +33,7 @@ var (
 		Path:      "path1",
 		Shorthand: "d",
 		Usage:     "First argument",
+		Secret:    true,
 	}
 
 	mutatorOption2 = PluginConfigOption{

--- a/sensu/goplugin.go
+++ b/sensu/goplugin.go
@@ -50,6 +50,9 @@ type PluginConfigOption struct {
 
 	// Usage adds help context to the command-line flag.
 	Usage string
+
+	// If secret option do not copy Argument value into Default
+	Secret bool
 }
 
 // PluginConfig defines the base plugin configuration.
@@ -192,6 +195,12 @@ func setupFlag(cmd *cobra.Command, opt *PluginConfigOption) error {
 		cmd.Flags().StringVarP(opt.Value.(*string), opt.Argument, opt.Shorthand, viper.GetString(opt.Argument), opt.Usage)
 	default:
 		return fmt.Errorf("invalid input type: %v", kind)
+	}
+	flag := cmd.Flags().Lookup(opt.Argument)
+	// Set empty DefValue string if option is a secret
+	// DefValue is only used for pflag usage message construction
+	if opt.Secret {
+		flag.DefValue = ""
 	}
 	return nil
 }


### PR DESCRIPTION
This closes #35 

I've tested this locally with a slightly edited influxdb handler.

Here's an example of my local test:
```
$ cat event.json | INFLUXDB_PASS="hey" INFLUXDB_USER="now" ./sensu-influxdb-handler

Debug::: User: now Pass: hey

Usage:
  sensu-influxdb-handler [flags]
  sensu-influxdb-handler [command]

Available Commands:
  help        Help about any command
  version     Print the version number of this plugin

Flags:
  -a, --addr string            the address of the influxdb server, should be of the form 'http://host:port', defaults to 'http://localhost:8086' or value of INFLUXDB_ADDR env variable (default "http://localhost:8086")
  -c, --check-status-metric    if true, the check status result will be captured as a metric
  -d, --db-name string         the influxdb to send metrics to
  -h, --help                   help for sensu-influxdb-handler
  -i, --insecure-skip-verify   if true, the influx client skips https certificate verification
  -p, --password string        the password for the given db, defaults to value of INFLUXDB_PASS env variable
      --precision string       the precision value of the metric (default "s")
  -u, --username string        the username for the given db, defaults to value of INFLUXDB_USER env variable

Use "sensu-influxdb-handler [command] --help" for more information about a command.

Error executing sensu-influxdb-handler: error validating input: missing db name
```

I added the initial Debug message in my local build of the influxdb handler to make sure I was setting the options correctly. 


Here are the changes I made in the influxdb handler to enable those two options as secrets.
```
$ git diff master main.go
diff --git a/main.go b/main.go
index a62805a..aeef86e 100644
--- a/main.go
+++ b/main.go
@@ -57,6 +57,7 @@ var (
                        Path:      username,
                        Env:       "INFLUXDB_USER",
                        Argument:  username,
+                       Secret:    true,
                        Shorthand: "u",
                        Default:   "",
                        Usage:     "the username for the given db, defaults to value of INFLUXDB_USER env variable",
@@ -66,6 +67,7 @@ var (
                        Path:      password,
                        Env:       "INFLUXDB_PASS",
                        Argument:  password,
+                       Secret:    true,
                        Shorthand: "p",
                        Default:   "",
                        Usage:     "the password for the given db, defaults to value of INFLUXDB_PASS env variable",
@@ -112,6 +114,7 @@ func main() {
 }
 
 func checkArgs(event *corev2.Event) error {
+       fmt.Printf("Debug::: User: %v Pass: %v\n", config.Username, config.Password)
        if len(config.DbName) == 0 {
                return errors.New("missing db name")
        }
```