### PR TITLE
don't setup a flag unless argument string is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Do not create commandline flag unless Argument is set for PluginConfigOption
 
 ## [0.7.0] - 2020-06-03
 

--- a/sensu/goplugin.go
+++ b/sensu/goplugin.go
@@ -141,6 +141,9 @@ func (p *basePlugin) setupFlags(cmd *cobra.Command) error {
 }
 
 func setupFlag(cmd *cobra.Command, opt *PluginConfigOption) error {
+	if len(opt.Argument) == 0 {
+		return nil
+	}
 	viper.BindEnv(opt.Argument, opt.Env)
 	if opt.Value == nil {
 		return errors.New("nil Value")


### PR DESCRIPTION
Really simple fix here

Don't setup a commandline flag when the Argument attribute in a PluginConfigOption is not set.
An empty string option name leads to some weird breakages and we shouldnt allow it.

Also with this fix we can now have  PluginConfigOptions that are only accessible via the keyspace+path.. which is an interesting side effect.
 