### PR TITLE
Add UnixTime func to template expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## [0.10.0] - 2020-10-07
+
+### Added
+Added UnixTime func to template expansion. See README for details.
+
 ## [0.9.0] - 2020-10-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -132,3 +132,41 @@ To run the plugin independently of Sensu (ex. test/dev), you must set the env va
 ```
 SENSU_LICENSE_FILE=$(sensuctl license info --format json)
 ```
+
+## Templates
+
+The templates package provides a wrapper to the [`text/template`][1] package
+allowing for the use of templates to expand event attributes.  An example of
+this would be using the following as part of a handler:
+
+```
+--summary-template "{{.Entity.Name}}/{{.Check.Name}}"
+```
+
+Which, if given an event with an entity name of webserver01 and a check name of
+check-nginx would yield `webserver01/check-nginx`.
+
+### UnixTime template function
+
+A Sensu Go event contains multiple timestamps (e.g. .Check.Issued,
+.Check.Executed, .Check.LastOk) that are presented in UNIX timestamp format.  A
+function named UnixTime is provided to print these values in a customizable
+human readable format as part of a template.  To customize the output format of
+the timestamp, use the same format as specified by Golang's [Time.Format][2].
+Additional examples can be found [here][3].
+
+**Note:** the predefined format constants are **not** available.
+
+The example below demonstrates its use:
+
+```
+[...]
+Service: {{.Entity.Name}}/{{.Check.Name}}
+Executed: {{(UnixTime .Check.Executed).Format "2 Jan 2006 15:04:05"}}
+Last OK: {{(UnixTime .Check.LastOK).Format "2 Jan 2006 15:04:05"}}
+[...]
+```
+
+[1]: https://golang.org/pkg/text/template/
+[2]: https://golang.org/pkg/time/#Time.Format
+[3]: https://yourbasic.org/golang/format-parse-string-time-date-example/

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"text/template"
+	"time"
 )
 
 func EvalTemplate(templName, templStr string, templSrc interface{}) (string, error) {
@@ -14,7 +15,9 @@ func EvalTemplate(templName, templStr string, templSrc interface{}) (string, err
 		return "", fmt.Errorf("must pass in template")
 	}
 
-	templ, err := template.New(templName).Parse(templStr)
+	templ, err := template.New(templName).Funcs(template.FuncMap{
+		"UnixTime": func(i int64) time.Time { return time.Unix(i, 0) },
+	}).Parse(templStr)
 	if err != nil {
 		return "", fmt.Errorf("Error building template: %s", err)
 	}

--- a/templates/templates_test.go
+++ b/templates/templates_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/sensu/sensu-go/types"
 	"github.com/stretchr/testify/assert"
 	"testing"
+	"time"
 )
 
 var (
@@ -29,9 +30,10 @@ func TestEvalTemplateUnixTime_Valid(t *testing.T) {
 	event := &types.Event{}
 	_ = json.Unmarshal(testEventBytes, event)
 
+	executed := time.Unix(event.Check.Executed, 0).Format("2 Jan 2006 15:04:05")
 	result, err := EvalTemplate("templOk", templateOkUnixTime, event)
 	assert.Nil(t, err)
-	assert.Equal(t, "Check: check-nginx Entity: webserver01 Executed: 10 Dec 2018 20:55:19 !", result)
+	assert.Equal(t, "Check: check-nginx Entity: webserver01 Executed: " + executed + " !", result)
 }
 
 // Variable not found

--- a/templates/templates_test.go
+++ b/templates/templates_test.go
@@ -9,6 +9,7 @@ import (
 
 var (
 	templateOk          = "Check: {{ .Check.Name }} Entity: {{ .Entity.Name }} !"
+	templateOkUnixTime  = "Check: {{ .Check.Name }} Entity: {{ .Entity.Name }} Executed: {{(UnixTime .Check.Executed).Format \"2 Jan 2006 15:04:05\"}} !"
 	templateVarNotFound = "Check: {{ .Check.NameZZZ }} Entity: {{ .Entity.Name }} !"
 	templateInvalid     = "Check: {{ .Check.Name Entity: {{ .Entity.Name }} !"
 )
@@ -21,6 +22,16 @@ func TestEvalTemplate_Valid(t *testing.T) {
 	result, err := EvalTemplate("templOk", templateOk, event)
 	assert.Nil(t, err)
 	assert.Equal(t, "Check: check-nginx Entity: webserver01 !", result)
+}
+
+// Valid test - Time Check
+func TestEvalTemplateUnixTime_Valid(t *testing.T) {
+	event := &types.Event{}
+	_ = json.Unmarshal(testEventBytes, event)
+
+	result, err := EvalTemplate("templOk", templateOkUnixTime, event)
+	assert.Nil(t, err)
+	assert.Equal(t, "Check: check-nginx Entity: webserver01 Executed: 10 Dec 2018 20:55:19 !", result)
 }
 
 // Variable not found


### PR DESCRIPTION
This allows for making timestamps readable and formattable using Golang's time format in a template.

Using the example contained in the test:

`"Check: {{ .Check.Name }} Entity: {{ .Entity.Name }} Executed: {{(UnixTime .Check.Executed).Format \"2 Jan 2006 15:04:05\"}} !"`

When expanded becomes:

`"Check: check-nginx Entity: webserver01 Executed: 10 Dec 2018 20:55:19 !"`

Signed-off-by: Todd Campbell <todd@sensu.io>