### PR TITLE
support handlers that need to pass through mutated json

### DIFF
--- a/sensu/handler.go
+++ b/sensu/handler.go
@@ -120,3 +120,13 @@ func (h *Handler) workflow(_ []string) (int, error) {
 func (h *Handler) Execute() {
 	h.framework.Execute()
 }
+
+// Disable Handler Event read
+func (h *Handler) DisableReadEvent() {
+	h.framework.SetEventRead(false)
+}
+
+// Disable Handler Event validation
+func (h *Handler) DisableEventValidation() {
+	h.framework.SetEventValidation(false)
+}

--- a/sensu/handler_test.go
+++ b/sensu/handler_test.go
@@ -141,6 +141,50 @@ func TestNewGoHandler(t *testing.T) {
 	assert.Nil(t, goHandler.framework.GetStdinEvent())
 	assert.Equal(t, os.Stdin, goHandler.framework.eventReader)
 }
+func TestNewHandler(t *testing.T) {
+	values := &handlerValues{}
+	options := getHandlerOptions(values)
+	goHandler := NewHandler(&defaultHandlerConfig, options, func(event *corev2.Event) error {
+		return nil
+	}, func(event *corev2.Event) error {
+		return nil
+	})
+
+	assert.NotNil(t, goHandler)
+	assert.NotNil(t, goHandler.framework.options)
+	assert.Equal(t, options, goHandler.framework.options)
+	assert.NotNil(t, goHandler.framework.config)
+	assert.Equal(t, &defaultHandlerConfig, goHandler.framework.config)
+	assert.NotNil(t, goHandler.validationFunction)
+	assert.NotNil(t, goHandler.executeFunction)
+	assert.Nil(t, goHandler.framework.GetStdinEvent())
+	assert.Equal(t, os.Stdin, goHandler.framework.eventReader)
+}
+func TestDisableReadEvent(t *testing.T) {
+	values := &handlerValues{}
+	options := getHandlerOptions(values)
+	goHandler := NewHandler(&defaultHandlerConfig, options, func(event *corev2.Event) error {
+		return nil
+	}, func(event *corev2.Event) error {
+		return nil
+	})
+	assert.NotNil(t, goHandler)
+	assert.Equal(t, true, goHandler.framework.readEvent)
+	goHandler.DisableReadEvent()
+	assert.Equal(t, false, goHandler.framework.readEvent)
+}
+func TestDisableEventValidation(t *testing.T) {
+	values := &handlerValues{}
+	options := getHandlerOptions(values)
+	goHandler := NewHandler(&defaultHandlerConfig, options, func(event *corev2.Event) error {
+		return nil
+	}, func(event *corev2.Event) error {
+		return nil
+	})
+	assert.Equal(t, true, goHandler.framework.eventValidation)
+	goHandler.DisableEventValidation()
+	assert.Equal(t, false, goHandler.framework.eventValidation)
+}
 
 func simpleTestUtil(t *testing.T, options []ConfigOption, args []string) (int, error) {
 	t.Helper()

--- a/sensu/plugin.go
+++ b/sensu/plugin.go
@@ -223,6 +223,13 @@ func (p *pluginFramework) SetWorkflow(f func([]string) (int, error)) {
 	p.pluginWorkflowFunction = f
 }
 
+func (p *pluginFramework) SetEventRead(f bool) {
+	p.readEvent = f
+}
+func (p *pluginFramework) SetEventValidation(f bool) {
+	p.eventValidation = f
+}
+
 func (p *pluginFramework) readSensuEvent() error {
 	eventJSON, err := ioutil.ReadAll(p.eventReader)
 	if err != nil {


### PR DESCRIPTION
In order to support mutated json passed into a handler, we need to disable eventRead and/or eventValidation.

Currently the SDK doesn't allow for this in the Handler concept. 

This PR adds additional Handler functions to explicitly disable these plugin framework properties before handler Execute() is called.

### Example handler use-case
building 'generic' webhook handlers to send json to arbitrary webhook url.
The payload needed by the receiving webhook would be mutated in the Sensu pipeline and will not longer be expected to be recognizable as a Sensu Event.

https://github.com/jspaleta/sensu-http-handler
This repo uses commits from this PR to disable event read so that arbitrary byte string on stdin can be passed to an external http endpoint