### PR TITLE
Add toJSON func to templates

### DIFF
--- a/templates/templates.go
+++ b/templates/templates.go
@@ -2,11 +2,13 @@ package templates
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
-	"github.com/google/uuid"
 	"os"
 	"text/template"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 func EvalTemplate(templName, templStr string, templSrc interface{}) (string, error) {
@@ -21,6 +23,7 @@ func EvalTemplate(templName, templStr string, templSrc interface{}) (string, err
 		"UnixTime":      func(i int64) time.Time { return time.Unix(i, 0) },
 		"UUIDFromBytes": uuid.FromBytes,
 		"Hostname":      os.Hostname,
+		"toJSON":        toJSON,
 	}).Parse(templStr)
 	if err != nil {
 		return "", fmt.Errorf("Error building template: %s", err)
@@ -33,4 +36,12 @@ func EvalTemplate(templName, templStr string, templSrc interface{}) (string, err
 	}
 
 	return buf.String(), nil
+}
+
+func toJSON(i any) string {
+	b, err := json.Marshal(i)
+	if err != nil {
+		return ""
+	}
+	return string(b)
 }

--- a/templates/templates_test.go
+++ b/templates/templates_test.go
@@ -18,6 +18,7 @@ var (
 	templateOkHostname  = "Check: {{ .Check.Name }} Entity: {{ .Entity.Name }} Hostname: {{Hostname}} !"
 	templateVarNotFound = "Check: {{ .Check.NameZZZ }} Entity: {{ .Entity.Name }} !"
 	templateInvalid     = "Check: {{ .Check.Name Entity: {{ .Entity.Name }} !"
+	templateJSON        = `{"name": "{{ .Check.Name }}", "output": {{ toJSON .Check.Output }}}`
 )
 
 // Valid test
@@ -98,4 +99,16 @@ func TestEvalTemplate_InvalidTemplate(t *testing.T) {
 	result, err := EvalTemplate("templOk", templateInvalid, event)
 	assert.Equal(t, "", result)
 	assert.NotNil(t, err)
+}
+
+// JSON template
+func TestEvalTemplate_JSONTemplate(t *testing.T) {
+	event := &corev2.Event{}
+	event.Check = &corev2.Check{}
+	event.Check.Name = "foo"
+	event.Check.Output = "foo\nbar"
+
+	result, err := EvalTemplate("templOk", templateJSON, event)
+	assert.Equal(t, `{"name": "foo", "output": "foo\nbar"}`, result)
+	assert.Nil(t, err)
 }


### PR DESCRIPTION
Adds a new `toJSON` function for use with template evaluation. It allows fields (e.g. `.Check.Output`) to be properly escaped when using JSON templates.